### PR TITLE
Localize subscription to only when admin is open

### DIFF
--- a/client/accounts_admin.js
+++ b/client/accounts_admin.js
@@ -74,11 +74,19 @@ Template.accountsAdmin.events({
   }
 });
 
-Template.accountsAdmin.rendered = function () {
-  Meteor.subscribe('filteredUsers', Session.get('userFilter'), Session.get('userFilterCriteria'), {
-    'onReady': function() {},
-    'onStop': function(error) { if (error) console.error(error);}
+Template.accountsAdmin.onCreated(function () {
+  this.subscribe('roles');
+  this.autorun(function (computation) {
+    Meteor.subscribe('filteredUsers', Session.get('userFilter'), Session.get('userFilterCriteria'), {
+      'onReady': function () {},
+      'onStop': function (error) {
+        if (error) console.error(error);
+      }
+    });
   });
+});
+
+Template.accountsAdmin.onRendered(function () {
   var searchElement = document.getElementsByClassName('search-input-filter');
   if (!searchElement)
     return;
@@ -90,6 +98,4 @@ Template.accountsAdmin.rendered = function () {
 
   searchElement[0].focus();
   searchElement[0].setSelectionRange(pos, pos);
-
-
-};
+});

--- a/client/startup.js
+++ b/client/startup.js
@@ -1,6 +1,0 @@
-Meteor.startup(function() {
-	Meteor.subscribe('roles');
-	Deps.autorun(function(e) {
-		Meteor.subscribe('filteredUsers', Session.get('userFilter'));
-	});
-});

--- a/package.js
+++ b/package.js
@@ -17,7 +17,6 @@ Package.on_use(function (api, where) {
   api.add_files('libs/role_hierarchy.js', ['client', 'server']);
 	api.add_files('libs/user_query.js', ['client', 'server']);
 
-	api.add_files('client/startup.js', 'client');
   api.add_files('client/roles_hierarchy_helpers.js', 'client');
 	api.add_files('client/accounts_admin.html', 'client');
 	api.add_files('client/accounts_admin.js', 'client');


### PR DESCRIPTION
Instead of globally subscribing to all data about users and roles, subscribe only when admin is shown.
